### PR TITLE
[FEATURE] Supress adding HTTP debug header by extension configuration

### DIFF
--- a/Classes/Controller/RoutingController.php
+++ b/Classes/Controller/RoutingController.php
@@ -326,6 +326,23 @@ class RoutingController
         //\TYPO3\CMS\Frontend\Page\PageGenerator::pagegenInit();
     }
 
+    /**
+     * Determine from extension configuration, if HTTP debug header can be added.
+     *
+     * @return boolean
+     */
+    public function supressHttpDebugHeader()
+    {
+        if (isset($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['routing'])) {
+            $extensionConfiguration = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['routing']);
+            if (is_array($extensionConfiguration) && array_key_exists('supressHttpDebugHeader', $extensionConfiguration)) {
+                if ($extensionConfiguration['supressHttpDebugHeader'] == '1') {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
 }
 
 /** @var \Causal\Routing\Controller\RoutingController $routing */
@@ -355,9 +372,11 @@ HTML;
     exit();
 }
 
-// Debugging information
-$routeName = $routing->getLastRouteName();
-if (!empty($routeName)) {
-    header('X-Causal-Routing-Route: ' . $routeName);
+// Add debugging information to HTTP response
+if ($routing->supressHttpDebugHeader() === false) {
+    $routeName = $routing->getLastRouteName();
+    if (!empty($routeName)) {
+        header('X-Causal-Routing-Route: ' . $routeName);
+    }
 }
 echo $ret;

--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -69,3 +69,15 @@ Nginx
 .. code-block:: nginx
 
 	rewrite ^/routing/(.*)$ /index.php?eID=routing&route=$1 last;
+
+HTTP Debug Header
+-----------------
+
+The name of the route is sent as an additional header line in the HTTP response to the client by default:
+
+..
+
+	X-Causal-Routing-Route: [ExtensionKey] Demo action with a parameter
+
+
+This can be deactivated (supressed) in the extension configuration (Extension Manager).

--- a/Resources/Private/Language/locallang.em.xlf
+++ b/Resources/Private/Language/locallang.em.xlf
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<xliff version="1.0">
+    <file source-language="en" datatype="plaintext" original="messages" date="2016-08-20T00:00:00Z" product-name="routing">
+        <header/>
+        <body>
+            <trans-unit id="supress_http_debug_header">
+                <source>Supress HTTP Debug Header:If ticked, the HTTP header X-Causal-Routing-Route is not added</source>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -1,0 +1,2 @@
+# cat=features/enable; type=boolean; label=LLL:EXT:routing/Resources/Private/Language/locallang.em.xlf:supress_http_debug_header
+supressHttpDebugHeader = 0


### PR DESCRIPTION
The name of the route is sent as an additional header line in the HTTP response to the client by default. For example:

`X-Causal-Routing-Route: [ExtensionKey] Demo action with a parameter`

Under certain circumstances is not desired.

This feature allows TYPO3 integrators to configure the extension and to supress adding this header line. This can be done in the Extension Manager (which requires admin privileges). The documentation has also been updated to reflect this new feature.
