### PR TITLE
[BUGFIX] Allow returning "0"

### DIFF
--- a/Classes/Controller/RoutingController.php
+++ b/Classes/Controller/RoutingController.php
@@ -364,7 +364,7 @@ if (!empty($routeName)) {
     header('X-Causal-Routing-Route: ' . $routeName);
 }
 
-if (empty($ret)) {
+if (is_string($ret) && $ret === '') {
     header('HTTP/1.1 204 No Content');
 }
 


### PR DESCRIPTION
PHP empty() function regards the string "0" as empty, although this
might well be a valid api output.

I would count int/float zeroes as "having content", too.