### PR TITLE
[BUGFIX] Use proper CamelCase for extension name and controller

### DIFF
--- a/Classes/Controller/RoutingController.php
+++ b/Classes/Controller/RoutingController.php
@@ -176,10 +176,15 @@ class RoutingController
                 $namespaceParts = explode('.', $controllerParameters['@package']);
                 if (count($namespaceParts) === 2) {
                     $controllerParameters['@vendor'] = $namespaceParts[0];
-                    $controllerParameters['@extension'] = GeneralUtility::underscoredToUpperCamelCase($namespaceParts[1]);
+                    $controllerParameters['@extension'] = $namespaceParts[1];
                 } else {
-                    $controllerParameters['@extension'] = GeneralUtility::underscoredToUpperCamelCase($namespaceParts[0]);
+                    $controllerParameters['@extension'] = $namespaceParts[0];
                 }
+                
+                if (ucfirst($controllerParameters['@extension']) !== $controllerParameters['@extension']) {
+                    $controllerParameters['@extension'] = GeneralUtility::underscoredToUpperCamelCase($controllerParameters['@extension']);
+                }
+                
                 if (empty($pluginParameters['action']) && !empty($controllerParameters['@action'])) {
                     $pluginParameters['action'] = $controllerParameters['@action'];
                 }
@@ -193,15 +198,19 @@ class RoutingController
                     $this->tangleFilesArray($pluginNamespace);
 
                     if (!empty($controllerParameters['@controller'])) {
+                        if (ucfirst($controllerParameters['@controller']) !== $controllerParameters['@controller']) {
+                            $controllerParameters['@controller'] = GeneralUtility::underscoredToUpperCamelCase($controllerParameters['@controller']);
+                        }
+
                         switch ($httpMethod) {
                             case 'DELETE':
                             case 'GET':
                             case 'PATCH':
                             case 'PUT':
-                                $pluginParameters['controller'] = GeneralUtility::underscoredToUpperCamelCase($controllerParameters['@controller']);
+                                $pluginParameters['controller'] = $controllerParameters['@controller'];
                                 break;
                             case 'POST':
-                                $_POST['controller'] = GeneralUtility::underscoredToUpperCamelCase($controllerParameters['@controller']);
+                                $_POST['controller'] = $controllerParameters['@controller'];
                                 break;
                         }
                     }


### PR DESCRIPTION
…tension name

See the following debug output:
var_dump($namespaceParts[1]);
var_dump(GeneralUtility::underscoredToUpperCamelCase($namespaceParts[1]));
string(13) "PartnerPoints"
string(13) "Partnerpoints"

This shows that applying underscoredToUpperCamelCase method to UpperCamelCase package definition results in inproper conversion of extension name. 

This then results in errors like:
The controller "XY" is not allowed by this plugin. Please check for TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin() in your ext_localconf.php.

Resolves: #17 