### PR TITLE
[FEATURE] Render headers from TSFE

### DIFF
--- a/Classes/Controller/RoutingController.php
+++ b/Classes/Controller/RoutingController.php
@@ -122,6 +122,9 @@ class RoutingController
             }
 
             $response = $bootstrap->run('', $configuration);
+
+            // Render headers from FE controller
+            $GLOBALS['TSFE']->processOutput();
         }
 
         return $response;


### PR DESCRIPTION
Render headers added to the TSFE by extbase. 

As the EidController creates a fake TSFE we will also need to render the headers, that Extbase Views may set on it. An example is the JsonView, that checks whether an TSFE exist and if so, sets the doctype on the TSFE, instead of rendering its own header. 

This might also address https://github.com/xperseguers/t3ext-routing/issues/6