### PR TITLE
[FEATURE] Additional Restful Json Request instead Form-Data Requests

### DIFF
--- a/Classes/Controller/RoutingController.php
+++ b/Classes/Controller/RoutingController.php
@@ -14,6 +14,8 @@
 
 namespace Causal\Routing\Controller;
 
+use Causal\Routing\DataHandler\DataHandlerFactory;
+use TYPO3\CMS\Core\Http\ServerRequest;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Frontend\Utility\EidUtility;
@@ -151,7 +153,8 @@ class RoutingController
     protected function getControllerParameters($subroute, $extensionKey = null)
     {
         $controllerParameters = null;
-        $httpMethod = $_SERVER['REQUEST_METHOD'];
+        $request = \TYPO3\CMS\Core\Http\ServerRequestFactory::fromGlobals();
+        $httpMethod = $request->getMethod();
 
         foreach ($this->routes as $route) {
             if (is_array($route['httpMethods'])) {
@@ -204,6 +207,8 @@ class RoutingController
                         $controllerParameters['@plugin']
                     );
 
+                    $bodyData = $this->objectManager->get(DataHandlerFactory::class)->getParsedBody($request);
+
                     $this->tangleFilesArray($pluginNamespace);
 
                     if (!empty($controllerParameters['@controller'])) {
@@ -218,14 +223,14 @@ class RoutingController
                                 $pluginParameters['controller'] = $controllerParameters['@controller'];
                                 break;
                             case 'POST':
-                                $_POST['controller'] = $controllerParameters['@controller'];
+                                $bodyData['controller'] = $controllerParameters['@controller'];
                                 break;
                         }
                     }
 
-                    $postKeys = array_keys($_POST);
+                    $postKeys = array_keys($bodyData);
                     foreach ($postKeys as $key) {
-                        $_POST[$pluginNamespace][$key] = $_POST[$key];
+                        $_POST[$pluginNamespace][$key] = $bodyData[$key];
                         unset($_POST[$key]);
                     }
 

--- a/Classes/DataHandler/AbstractDataHandler.php
+++ b/Classes/DataHandler/AbstractDataHandler.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Causal\Routing\DataHandler;
+
+use TYPO3\CMS\Core\Http\ServerRequest;
+
+abstract class AbstractDataHandler
+{
+    /**
+     * @var ServerRequest
+     */
+    protected $request;
+
+    public function __construct(ServerRequest $request)
+    {
+        $this->request = $request;
+    }
+
+    /**
+     * Retrieves the session token.
+     *
+     * @return array
+     */
+    abstract public function getParsedBody();
+}

--- a/Classes/DataHandler/DataHandlerFactory.php
+++ b/Classes/DataHandler/DataHandlerFactory.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Causal\Routing\DataHandler;
+
+use Causal\Routing\DataHandler\AbstractDataHandler;
+use Causal\Routing\DataHandler\DefaultDataHandler;
+use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+class DataHandlerFactory
+{
+    /**
+     * @var \TYPO3\CMS\Extbase\Object\ObjectManager
+     */
+    protected $objectManager;
+
+    /**
+     * Default contructor.
+     */
+    public function __construct()
+    {
+        $this->objectManager = GeneralUtility::makeInstance(\TYPO3\CMS\Extbase\Object\ObjectManager::class);
+    }
+
+    /**
+     * @param ServerRequest $request
+     * @return array
+     */
+    public function getParsedBody(ServerRequest $request)
+    {
+        $dataHandler = $this->getDataHandler($request);
+        return $dataHandler->getParsedBody();
+    }
+
+    /**
+     * @param ServerRequest $request
+     * @return DefaultDataHandler|object
+     */
+    protected function getDataHandler(ServerRequest $request)
+    {
+        $mimeType = $request->getHeaderLine('content-type');
+        if ($dataHandler = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['routing']['dataHandler'][$mimeType]) {
+            return $this->objectManager->get($dataHandler);
+        }
+        return $this->objectManager->get(DefaultDataHandler::class, $request);
+    }
+}

--- a/Classes/DataHandler/DefaultDataHandler.php
+++ b/Classes/DataHandler/DefaultDataHandler.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Causal\Routing\DataHandler;
+
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+class DefaultDataHandler extends AbstractDataHandler
+{
+    public function getParsedBody()
+    {
+        $data = [];
+        switch ($this->request->getMethod()) {
+            case 'POST':
+                $data = $_POST;
+                break;
+            case 'PUT':
+            case 'PATCH':
+            case 'DELETE':
+                $bodyContent = $this->request->getBody()->getContents();
+                $data = $this->parseFormData($bodyContent);
+                break;
+        }
+        return $data;
+    }
+
+    /**
+     * @param string $rawData
+     * @return array|void
+     */
+    protected function parseFormData($rawData)
+    {
+        // Fetch content and determine boundary
+        $boundary = substr($rawData, 0, strpos($rawData, "\r\n"));
+        if (empty($boundary)) {
+            return;
+        }
+        // Fetch each part
+        $parts = array_slice(explode($boundary, $rawData), 1);
+        $data = array();
+
+        foreach ($parts as $part) {
+            // If this is the last part, break
+            if ($part == "--\r\n") {
+                break;
+            }
+            // Separate content from headers
+            $part = ltrim($part, "\r\n");
+            list($rawHeaders, $body) = explode("\r\n\r\n", $part, 2);
+
+            // Parse the headers list
+            $rawHeaders = explode("\r\n", $rawHeaders);
+            $headers = array();
+            foreach ($rawHeaders as $header) {
+                list($name, $value) = explode(':', $header);
+                $headers[strtolower($name)] = ltrim($value, ' ');
+            }
+
+            // Parse the Content-Disposition to get the field name, etc.
+            if (isset($headers['content-disposition'])) {
+                $filename = null;
+                $tmp_name = null;
+                preg_match(
+                    '/^(.+); *name="([^"]+)"(; *filename="([^"]+)")?/',
+                    $headers['content-disposition'],
+                    $matches
+                );
+                $name = $matches[2];
+                //Parse File
+                if (isset($matches[4])) {
+                    // TODO: Add Files
+                    //$this->addFiles($matches, $body, $value);
+                } else { //Parse Field
+                    $params = $name . '=' . substr($body, 0, strlen($body) - 2);
+                    $data = array_merge_recursive($data, GeneralUtility::explodeUrl2Array($params, 1));
+                }
+            }
+        }
+        return $data;
+    }
+
+    protected function addFiles($matches, $body, $value)
+    {
+        //if labeled the same as previous, skip
+        if (isset($_FILES[$matches[2]])) {
+            return;
+        }
+        //get filename
+        $filename = $matches[4];
+
+        //get tmp name
+        $filename_parts = pathinfo($filename);
+        $tmp_name = tempnam(ini_get('upload_tmp_dir'), $filename_parts['filename']);
+
+        //populate $_FILES with information, size may be off in multibyte situation
+        $_FILES[$matches[2]] = array(
+            'error' => 0,
+            'name' => $filename,
+            'tmp_name' => $tmp_name,
+            'size' => strlen($body),
+            'type' => $value
+        );
+        //place in temporary directory
+        file_put_contents($tmp_name, $body);
+    }
+}

--- a/Classes/DataHandler/JsonDataHandler.php
+++ b/Classes/DataHandler/JsonDataHandler.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Causal\Routing\DataHandler;
+
+class JsonDataHandler extends AbstractDataHandler
+{
+    public function getParsedBody()
+    {
+        $bodyContent = $this->request->getBody()->getContents();
+        return json_decode($bodyContent, 1) ?: [];
+    }
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -9,3 +9,5 @@ $boot = function ($_EXTKEY) {
 
 $boot($_EXTKEY);
 unset($boot);
+// Add Json DataHandler
+$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['routing']['dataHandler']['application/json'] = \Causal\Routing\DataHandler\JsonDataHandler::class;


### PR DESCRIPTION
This pull request adds the option to send data in json format instead of standard form-data. Prerequisite is that on the request  the content type  is set to "application / Json". If no content type has been specified, the form data can be sent as before.

Json Post Sample:
```
curl --request POST http://localhost/routing/extension-key/my/demo/product
{
    "newProduct": {
        "type":"sample",
        "title":"sample"
    }
}
```