### PR TITLE
[FEATURE] add OPTIONS http method

### DIFF
--- a/Classes/Controller/RoutingController.php
+++ b/Classes/Controller/RoutingController.php
@@ -213,6 +213,7 @@ class RoutingController
                         switch ($httpMethod) {
                             case 'DELETE':
                             case 'GET':
+                            case 'OPTIONS':
                             case 'PATCH':
                             case 'PUT':
                                 $pluginParameters['controller'] = $controllerParameters['@controller'];


### PR DESCRIPTION
HTTP OPTIONS will enable controller to handle ajax preflights

Howto handle preflights:
1. Add route
2. Implement controller action and preflight

### Add route

```
-
  name: 'preflight foo route'
  uriPattern: 'some/uri'
  defaults:
    '@package':    'SOME.package'
    '@plugin':     'default'
    '@controller': 'Rest'
    '@action':     'preflightFoo'
  httpMethods: ['OPTIONS']
-
  name: 'foo route'
  uriPattern: 'some/uri'
  defaults:
    '@package':    'SOME.package'
    '@plugin':     'default'
    '@controller': 'Rest'
    '@action':     'foo'
  httpMethods: ['GET']
```

### Implement controller action and preflight

```
	/**
	 * preflight action
	 */
	public function preflightFooAction()
	{
               #Doing some stuff to handle the preflight
               $this->controllerContext->getResponse()->setHeader('Access-Control-Allow-Origin', 'https://api.example.com);
               $this->controllerContext->getResponse()->setHeader('Access-Control-Allow-Headers', 'Authorization');

               #return empty response
               #firefox only accept repsonse with StatusCode 200 NOT 204 in my case
	}

	/**
	 * foo action
	 */
	public function fooAction()
	{
	}
```

